### PR TITLE
octocovが効いているかテスト

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -10,44 +10,41 @@ on:
       - main
 
 jobs:
-  # Lint:
-  #   runs-on: ubuntu-latest
-  #   permissions:
-  #     pull-requests: write
-  #     contents: read
+  Lint:
+    runs-on: ubuntu-latest
 
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v4
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
 
-  #     - name: Set up Go
-  #       uses: actions/setup-go@v4
-  #       id: setup-go-lint
-  #       with:
-  #         go-version-file: ./api_server/go.mod
-  #         cache: true
-  #         cache-dependency-path: ./api_server/go.sum
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        id: setup-go-lint
+        with:
+          go-version-file: ./api_server/go.mod
+          cache: true
+          cache-dependency-path: ./api_server/go.sum
 
-  #     - name: go mod tidy
-  #       working-directory: ./api_server
-  #       if: ${{ steps.setup-go-lint.outputs.cache-hit != 'true' }}
-  #       run: go mod tidy
+      - name: go mod tidy
+        working-directory: ./api_server
+        if: ${{ steps.setup-go-lint.outputs.cache-hit != 'true' }}
+        run: go mod tidy
 
-  #     - name: Generate reviewdog api token
-  #       id: generate_token
-  #       uses: tibdex/github-app-token@v1
-  #       with:
-  #         app_id: ${{ secrets.REVIEDOG_APP_ID }}
-  #         private_key: ${{ secrets.REVIEDOG_PRIVATE_KEY }}
+      - name: Generate reviewdog api token
+        id: generate_token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.REVIEDOG_APP_ID }}
+          private_key: ${{ secrets.REVIEDOG_PRIVATE_KEY }}
 
-  #     - name: Setup reviewdog
-  #       uses: reviewdog/action-setup@v1
+      - name: Setup reviewdog
+        uses: reviewdog/action-setup@v1
 
-  #     - name: lint
-  #       env:
-  #         REVIEWDOG_GITHUB_API_TOKEN: ${{ steps.generate_token.outputs.token }}
-  #       working-directory: ./api_server
-  #       run: go install honnef.co/go/tools/cmd/staticcheck@latest && staticcheck ./... | reviewdog -reporter=github-pr-review -f=staticcheck -level=warn -filter-mode=nofilter -fail-level=any
+      - name: lint
+        env:
+          REVIEWDOG_GITHUB_API_TOKEN: ${{ steps.generate_token.outputs.token }}
+        working-directory: ./api_server
+        run: go install honnef.co/go/tools/cmd/staticcheck@latest && staticcheck ./... | reviewdog -reporter=github-pr-review -f=staticcheck -level=warn -filter-mode=nofilter -fail-level=any
 
   Test:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -146,12 +146,12 @@ jobs:
         if: always()
         run: |
           mkdir -p coverage/html
-          mv api_server/coverage.out coverage/html
+          mv api_server/coverage.out coverage/html/backend
           echo "<ul><li><a href="backend">backend</li></ul>" > coverage/html/index.html
 
       - uses: rajyan/preview-pages@v1
         if: always()
         with:
           source-dir: coverage/html
-          branch-per-commit: false
+          branch-per-commit: ${{ github.event_name == 'pull_request'}}
           pr-comment: hide_and_recreate

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -12,6 +12,9 @@ on:
 jobs:
   Lint:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
 
     steps:
       - name: Checkout

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -137,17 +137,20 @@ jobs:
 
       - name: Report coverage
         uses: k1LoW/octocov-action@v1
+        if: always()
         env:
           SANITIZED_REF: ${{ env.SANITIZED_REF }}
           SANITIZED_BASE_REF: ${{ env.SANITIZED_BASE_REF }}
 
       - name: Setup pages
+        if: always()
         run: |
           mkdir -p coverage/html
           mv api_server/coverage.out coverage/html
           echo "<ul><li><a href="backend">backend</li></ul>" > coverage/html/index.html
 
       - uses: rajyan/preview-pages@v1
+        if: always()
         with:
           source-dir: coverage/html
           branch-per-commit: false

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -135,8 +135,16 @@ jobs:
           SANITIZED_BASE_REF="${BASE_REF//\//_}"
           echo "SANITIZED_BASE_REF=$SANITIZED_BASE_REF" >> $GITHUB_ENV
 
+      - name: Generate reviewdog api token
+        id: test_generate_token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.REVIEDOG_APP_ID }}
+          private_key: ${{ secrets.REVIEDOG_PRIVATE_KEY }}
+
       - name: Report coverage
         uses: k1LoW/octocov-action@v1
         env:
           SANITIZED_REF: ${{ env.SANITIZED_REF }}
           SANITIZED_BASE_REF: ${{ env.SANITIZED_BASE_REF }}
+          GITHUB_TOKEN: ${{ steps.test_generate_token.outputs.token }}

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -51,6 +51,9 @@ jobs:
 
   Test:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
 
     services:
       db:

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -146,7 +146,7 @@ jobs:
         if: always()
         run: |
           mkdir -p coverage/html
-          mv api_server/coverage.out coverage/html/backend
+          mv api_server/coverage.out coverage/html/backend/index.html
           echo "<ul><li><a href="backend">backend</a></li></ul>" > coverage/html/index.html
 
       - uses: rajyan/preview-pages@v1

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -146,6 +146,7 @@ jobs:
         if: always()
         run: |
           mkdir -p coverage/html
+          mkdir -p coverage/html/backend
           mv api_server/coverage.out coverage/html/backend/index.html
           echo "<ul><li><a href="backend">backend</a></li></ul>" > coverage/html/index.html
 

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -10,44 +10,44 @@ on:
       - main
 
 jobs:
-  Lint:
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-      contents: read
+  # Lint:
+  #   runs-on: ubuntu-latest
+  #   permissions:
+  #     pull-requests: write
+  #     contents: read
 
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v4
 
-      - name: Set up Go
-        uses: actions/setup-go@v4
-        id: setup-go-lint
-        with:
-          go-version-file: ./api_server/go.mod
-          cache: true
-          cache-dependency-path: ./api_server/go.sum
+  #     - name: Set up Go
+  #       uses: actions/setup-go@v4
+  #       id: setup-go-lint
+  #       with:
+  #         go-version-file: ./api_server/go.mod
+  #         cache: true
+  #         cache-dependency-path: ./api_server/go.sum
 
-      - name: go mod tidy
-        working-directory: ./api_server
-        if: ${{ steps.setup-go-lint.outputs.cache-hit != 'true' }}
-        run: go mod tidy
+  #     - name: go mod tidy
+  #       working-directory: ./api_server
+  #       if: ${{ steps.setup-go-lint.outputs.cache-hit != 'true' }}
+  #       run: go mod tidy
 
-      - name: Generate reviewdog api token
-        id: generate_token
-        uses: tibdex/github-app-token@v1
-        with:
-          app_id: ${{ secrets.REVIEDOG_APP_ID }}
-          private_key: ${{ secrets.REVIEDOG_PRIVATE_KEY }}
+  #     - name: Generate reviewdog api token
+  #       id: generate_token
+  #       uses: tibdex/github-app-token@v1
+  #       with:
+  #         app_id: ${{ secrets.REVIEDOG_APP_ID }}
+  #         private_key: ${{ secrets.REVIEDOG_PRIVATE_KEY }}
 
-      - name: Setup reviewdog
-        uses: reviewdog/action-setup@v1
+  #     - name: Setup reviewdog
+  #       uses: reviewdog/action-setup@v1
 
-      - name: lint
-        env:
-          REVIEWDOG_GITHUB_API_TOKEN: ${{ steps.generate_token.outputs.token }}
-        working-directory: ./api_server
-        run: go install honnef.co/go/tools/cmd/staticcheck@latest && staticcheck ./... | reviewdog -reporter=github-pr-review -f=staticcheck -level=warn -filter-mode=nofilter -fail-level=any
+  #     - name: lint
+  #       env:
+  #         REVIEWDOG_GITHUB_API_TOKEN: ${{ steps.generate_token.outputs.token }}
+  #       working-directory: ./api_server
+  #       run: go install honnef.co/go/tools/cmd/staticcheck@latest && staticcheck ./... | reviewdog -reporter=github-pr-review -f=staticcheck -level=warn -filter-mode=nofilter -fail-level=any
 
   Test:
     runs-on: ubuntu-latest
@@ -135,16 +135,8 @@ jobs:
           SANITIZED_BASE_REF="${BASE_REF//\//_}"
           echo "SANITIZED_BASE_REF=$SANITIZED_BASE_REF" >> $GITHUB_ENV
 
-      - name: Generate reviewdog api token
-        id: test_generate_token
-        uses: tibdex/github-app-token@v1
-        with:
-          app_id: ${{ secrets.REVIEDOG_APP_ID }}
-          private_key: ${{ secrets.REVIEDOG_PRIVATE_KEY }}
-
       - name: Report coverage
         uses: k1LoW/octocov-action@v1
         env:
           SANITIZED_REF: ${{ env.SANITIZED_REF }}
           SANITIZED_BASE_REF: ${{ env.SANITIZED_BASE_REF }}
-          GITHUB_TOKEN: ${{ steps.test_generate_token.outputs.token }}

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -50,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
-      contents: read
+      contents: write
 
     services:
       db:
@@ -140,3 +140,15 @@ jobs:
         env:
           SANITIZED_REF: ${{ env.SANITIZED_REF }}
           SANITIZED_BASE_REF: ${{ env.SANITIZED_BASE_REF }}
+
+      - name: Setup pages
+        run: |
+          mkdir -p coverage/html
+          mv api_server/coverage.out coverage/html
+          echo "<ul><li><a href="backend">backend</li></ul>" > coverage/html/index.html
+
+      - uses: rajyan/preview-pages@v1
+        with:
+          source-dir: coverage/html
+          branch-per-commit: false
+          pr-comment: hide_and_recreate

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -147,7 +147,7 @@ jobs:
         run: |
           mkdir -p coverage/html
           mv api_server/coverage.out coverage/html/backend
-          echo "<ul><li><a href="backend">backend</li></ul>" > coverage/html/index.html
+          echo "<ul><li><a href="backend">backend</a></li></ul>" > coverage/html/index.html
 
       - uses: rajyan/preview-pages@v1
         if: always()

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -147,7 +147,7 @@ jobs:
         run: |
           mkdir -p coverage/html
           mkdir -p coverage/html/backend
-          mv api_server/coverage.out coverage/html/backend/index.html
+          mv api_server/coverage.out.html coverage/html/backend/index.html
           echo "<ul><li><a href="backend">backend</a></li></ul>" > coverage/html/index.html
 
       - uses: rajyan/preview-pages@v1

--- a/api_server/Makefile
+++ b/api_server/Makefile
@@ -15,6 +15,7 @@ test-local:
 test-ci:
 	cd db && godotenv -f /app/.env.test sql-migrate up -env="mysql" && cd ..
 	godotenv -f /app/.env.test go test -v ./... -p 1  -shuffle=on -coverprofile=coverage.out
+	go tool cover -html coverage.out -o coverage.out.html
 
 prepare-sqlboiler:
 	@go get -u github.com/tiendc/sqlboiler-extensions@$(BOIL_EXT_VER)

--- a/api_server/services/todo_service.go
+++ b/api_server/services/todo_service.go
@@ -6,6 +6,7 @@ import (
 	"app/validator"
 	"context"
 	"database/sql"
+	"fmt"
 	"net/http"
 
 	"github.com/volatiletech/null/v8"
@@ -35,6 +36,7 @@ func (ts *todoService) CreateTodo(ctx context.Context, requestParams apis.PostTo
 	if validationErrors != nil {
 		return int(http.StatusBadRequest), validationErrors
 	}
+	fmt.Println(validationErrors)
 
 	todo := &models.Todo{}
 	todo.Title = requestParams.Title
@@ -43,6 +45,7 @@ func (ts *todoService) CreateTodo(ctx context.Context, requestParams apis.PostTo
 	// NOTE: Create処理
 	err = todo.Insert(ctx, ts.db, boil.Infer())
 	if err != nil {
+		fmt.Println(err)
 		return int(http.StatusInternalServerError), err
 	}
 	return int(http.StatusOK), nil

--- a/api_server/services/todo_service.go
+++ b/api_server/services/todo_service.go
@@ -36,7 +36,7 @@ func (ts *todoService) CreateTodo(ctx context.Context, requestParams apis.PostTo
 	if validationErrors != nil {
 		return int(http.StatusBadRequest), validationErrors
 	}
-	fmt.Println("validationError", validationErrors)
+	fmt.Println("validationErrors", validationErrors)
 
 	todo := &models.Todo{}
 	todo.Title = requestParams.Title

--- a/api_server/services/todo_service.go
+++ b/api_server/services/todo_service.go
@@ -36,7 +36,7 @@ func (ts *todoService) CreateTodo(ctx context.Context, requestParams apis.PostTo
 	if validationErrors != nil {
 		return int(http.StatusBadRequest), validationErrors
 	}
-	fmt.Println(validationErrors)
+	fmt.Println("validationErrors", validationErrors)
 
 	todo := &models.Todo{}
 	todo.Title = requestParams.Title

--- a/api_server/services/todo_service.go
+++ b/api_server/services/todo_service.go
@@ -36,7 +36,7 @@ func (ts *todoService) CreateTodo(ctx context.Context, requestParams apis.PostTo
 	if validationErrors != nil {
 		return int(http.StatusBadRequest), validationErrors
 	}
-	fmt.Println("validationErrors", validationErrors)
+	fmt.Println("validationError", validationErrors)
 
 	todo := &models.Todo{}
 	todo.Title = requestParams.Title

--- a/octocov.yml
+++ b/octocov.yml
@@ -18,6 +18,7 @@ codeToTestRatio: # NOTE: 実装コードの行数を1とした場合のテスト
     - 'api_server/**/*_test.go'
   acceptable: current >= 0.1 && diff >= 0 # NOTE: この数値を下回るとワークフローがfailする
 comment: # NOTE: レポート内容をコメント投稿設定
+  if: is_pull_request # PRの場合のみコメントを投稿する
   hideFooterLink: false # フッターのoctocovのリンクを非表示にしない
 report: # NOTE: レポートの出力設定
   datastores:

--- a/octocov.yml
+++ b/octocov.yml
@@ -18,7 +18,6 @@ codeToTestRatio: # NOTE: 実装コードの行数を1とした場合のテスト
     - 'api_server/**/*_test.go'
   acceptable: current >= 0.1 && diff >= 0 # NOTE: この数値を下回るとワークフローがfailする
 comment: # NOTE: レポート内容をコメント投稿設定
-  if: is_pull_request # PRの場合のみコメントを投稿する
   hideFooterLink: false # フッターのoctocovのリンクを非表示にしない
 report: # NOTE: レポートの出力設定
   datastores:


### PR DESCRIPTION
## Ref
- Github Pagesを用いたテスト未実行の行の可視化
  - https://www.estie.jp/blog/entry/2024/08/09/141550

以下の点が微妙だね...
- PRの変更差分のカバレッジチェックが不可
- チェックの正確性が少し微妙(以下のように画像のように変更がないはずなのに減少となってしまっている)
- PR上のコメントの上書きが不可(commitが足される度に新規に作られる)
- 変更差分のテスト未実行の行の特定が困難
  - Github Pagesを用いた方法だと、実装時やレビュー時に見に行く必要があるので煩わしい
- force pushするとその分のカバレッジレポートが出力されなくなる

<img width="963" alt="スクリーンショット 2025-05-13 13 44 40" src="https://github.com/user-attachments/assets/bd5b2d49-fee3-41f5-835b-2b09a88823f2" />
